### PR TITLE
docker: added minio to compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,14 @@ POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="postgres"
 POSTGRES_DB="visiteo"
 POSTGRES_URI="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+
+#------------------------------------------ 
+# 📦 S3 Хранилище
+#------------------------------------------
+S3_HOST="localhost"
+S3_PORT=9000
+S3_ACCESS_KEY_ID="minio"
+S3_SECRET_ACCESS_KEY="minio123"
+S3_IMAGES_BUCKET="images"
+S3_ENDPOINT=http://${S3_HOST}:${S3_PORT}
+S3_REGION=eu-west-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,48 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - backend
-
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+  minio:
+    image: minio/minio:latest
+    entrypoint: sh
+    ports:
+      - "${S3_PORT}:9000"
+      - "9001:9001"
+    command: -c 'minio server --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY}
+    volumes:
+      - minio-data:/data
+    networks:
+      - backend
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set myminio http://minio:9000 ${S3_ACCESS_KEY_ID} ${S3_SECRET_ACCESS_KEY};
+      /usr/bin/mc mb myminio/${S3_IMAGES_BUCKET};
+      /usr/bin/mc anonymous set public myminio/${S3_IMAGES_BUCKET};
+      exit 0;
+      "
+    networks:
+      - backend
 volumes:
   postgres_data:
+  minio-data:
 
 networks:
   backend:


### PR DESCRIPTION
Вот описание для pull request:

# 🚀 Добавление локального S3 и PostgreSQL хранилища

## 📝 Описание
Добавлена конфигурация для локального развертывания S3 (MinIO) и PostgreSQL с помощью Docker Compose.

## 🔧 Как использовать

1. Скопируйте `.env.example` в `.env`:
```bash
cp .env.example .env
```

2. Запустите контейнеры:
```bash
docker compose up -d
```

3. После запуска будут доступны:
- PostgreSQL: `localhost:5432`
- MinIO S3: `localhost:9000`
- MinIO Console: `localhost:9001`

## 📦 Доступ к сервисам

### PostgreSQL
- User: `postgres`
- Password: `postgres`
- Database: `visiteo`

### MinIO (S3)
- Access Key: `minio`
- Secret Key: `minio123`
- Bucket: `images`
- Console URL: http://localhost:9001

## ✅ Проверка работоспособности
- PostgreSQL автоматически проверяет готовность через healthcheck
- MinIO создает публичный bucket `images` при первом запуске
- Все данные сохраняются в Docker volumes: `postgres_data` и `minio-data`
